### PR TITLE
ADR: 0002 - No headless CMSes

### DIFF
--- a/docs/architecture/decisions/0002-no-headless-cms.md
+++ b/docs/architecture/decisions/0002-no-headless-cms.md
@@ -1,0 +1,22 @@
+# 2. No Headless CMSes
+
+Date: 2023-07-11
+
+## Status
+
+Proposed
+
+## Context
+
+It's early in the build phase of the project and we are trying to determine what CMS we
+want to use or if we should build something ourselves. We are
+[evaluating several options](https://docs.google.com/spreadsheets/d/1SKajxihDa6qzT2Rt3GgJd8PT2B8gDkGZDGO1hK2TwLg/edit#gid=61753279),
+including traditional CMSes as well as headless CMSes.
+
+## Decision
+
+We will not use a headless CMS because they all, by definition, require that we create the entire frontend, including rendering. While it may not be too difficult technically, it does introduce substantial technical debt and upkeep requirements. A traditional CMS with an existing rendering pipeline we can just plug into should be far more maintainable in the long term.
+
+## Consequences
+
+We will have fewer options for CMSes.


### PR DESCRIPTION
# 2. No Headless CMSes

Date: 2023-07-11

## Status

Draft

## Context

It's early in the build phase of the project and we are trying to determine what CMS we want to use or if we should build something ourselves. We are [evaluating several options](https://docs.google.com/spreadsheets/d/1SKajxihDa6qzT2Rt3GgJd8PT2B8gDkGZDGO1hK2TwLg/edit#gid=61753279), including traditional CMSes as well as headless CMSes. We've also [documented the difference](https://docs.google.com/document/d/1xJELw4BJ_UzkG9jGTXe0TeKcE4fmkJoDdNe15vrvPng/edit) between the two types of CMS.

## Decision

We will not use a headless CMS because they all, by definition, require that we create the entire frontend, including rendering. While it may not be too difficult technically, it does introduce substantial technical debt and upkeep requirements. A traditional CMS with an existing rendering pipeline we can just plug into should be far more maintainable in the long term.

## Consequences

- We will have fewer options for CMSes.
- Building a single-page app (SPA) frontend would be more difficult. (Note that we are not required to build a SPA, and maybe don't even want to.)