### PR TITLE
ADR 0004 - We will use NOAA WOC for hosting

### DIFF
--- a/docs/architecture/decisions/0004-use-noaa-woc-hosting.md
+++ b/docs/architecture/decisions/0004-use-noaa-woc-hosting.md
@@ -1,0 +1,25 @@
+# 4. We will use NOAA WOC for hosting
+
+Date: 2023-07-13
+
+## Status
+
+Proposed
+
+## Context
+
+weather.gov has to be hosted somewhere in order to be available on the internet.
+Where we choose to host the product can have significant impacts on what we are
+able to build. Ideally, we would like to use a hosting provider that is already
+approved within NOAA/NWS rather than procuring something new.
+
+## Decision
+
+We have chosen to use the NOAA WOC as our hosting provider. It is already
+approved and supported within NOAA, and it is built on a large-scale commercial
+cloud provider that gives us a lot of freedom with what we build.
+
+## Consquences
+
+The WOC introduces another relationship and that could sometimes result in
+delays getting something done because we need their support or approval.

--- a/docs/architecture/decisions/0004-use-noaa-woc-hosting.md
+++ b/docs/architecture/decisions/0004-use-noaa-woc-hosting.md
@@ -19,7 +19,7 @@ We have chosen to use the NOAA WOC as our hosting provider. It is already
 approved and supported within NOAA, and it is built on a large-scale commercial
 cloud provider that gives us a lot of freedom with what we build.
 
-## Consquences
+## Consequences
 
 The WOC introduces another relationship and that could sometimes result in
 delays getting something done because we need their support or approval.


### PR DESCRIPTION
# 4. We will use NOAA WOC for hosting

Date: 2023-07-13

## Status

Proposed

## Context

weather.gov has to be hosted somewhere in order to be available on the internet. Where we choose to host the product can have significant impacts on what we are able to build. Ideally, we would like to use a hosting provider that is already approved within NOAA/NWS rather than procuring something new.

## Decision

We have chosen to use the NOAA WOC as our hosting provider. It is already approved and supported within NOAA, and it is built on a large-scale commercial cloud provider that gives us a lot of freedom with what we build.

## Consequences

The WOC introduces another relationship and that could sometimes result in delays getting something done because we need their support or approval.

The WOC is using a particular commercial cloud hosting provider. While we will work towards a platform-agnostic application, the reality is that the plumbing to connect an application to its underlying infrastructure is always platform specific, so using the WOC will create a lock-in risk. (This risk is inherent in any hosting decision, but documenting it for completeness.)