### PR TITLE
Tinkering: Add observation station location and distance; some cacheing updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "weather.gov",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "weather.gov",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,3 +1,27 @@
 {
-  "prettier": {}
+  "name": "weather.gov",
+  "description": "",
+  "version": "1.0.0",
+  "main": "index.js",
+  "contributors": [
+    "Claire Annan",
+    "Stacy Dion",
+    "Shad Keene",
+    "Sarah MH",
+    "Colin Murphy",
+    "Katrina Ranjo",
+    "Kari Sheets",
+    "Greg Walker",
+    "Janel Yamashiro"
+  ],
+  "license": "CC0-1.0",
+  "directories": {
+    "doc": "docs"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "prettier": "^3.0.0"
+  },
+  "prettier": {},
+  "scripts": {}
 }

--- a/src/index.html
+++ b/src/index.html
@@ -40,6 +40,7 @@
         <div id="obs_text"></div>
         <div id="obs_temperature"></div>
         <div id="obs_time"></div>
+        <div id="obs_loc"></div>
       </div>
 
       <h3>Forecast</h3>

--- a/src/lib/location.js
+++ b/src/lib/location.js
@@ -21,6 +21,13 @@ export class UnknownLocationError extends Error {
   }
 }
 
+// When the user allows us to ask for their location, store the location that
+// the browser gives us. We can use this saved location instead of querying the
+// browser again so the page loads faster the next time. We can ask the browser
+// for their location in the background and then update the UI when we get the
+// new value back.
+const LOCAL_STORAGE_KEY = "weathergov - user browser location";
+
 export default class Location {
   constructor() {
     this._geolocation = navigator.geolocation;
@@ -28,6 +35,17 @@ export default class Location {
 
   #_getSuccess(resolve) {
     return (o) => {
+      const {
+        coords: { latitude, longitude },
+        timestamp,
+      } = o;
+
+      // Store the new location so we can use it the next time the user loads
+      // the page.
+      localStorage.setItem(
+        LOCAL_STORAGE_KEY,
+        JSON.stringify({ coords: { latitude, longitude }, timestamp })
+      );
       resolve(o);
     };
   }
@@ -51,6 +69,33 @@ export default class Location {
   }
 
   async get() {
+    try {
+      // See if we have stored the user's location in their browser. If so, we
+      // may be able to reuse it instead of getting their location again. To
+      // protect against weird data, all of this is in a try/catch. The catch
+      // doesn't do anything, so any exceptions will fall back to fetching the
+      // user's location as if it is not stored.
+      const storedLocation = JSON.parse(
+        localStorage.getItem(LOCAL_STORAGE_KEY)
+      );
+
+      if (storedLocation) {
+        const thirtyMinutesAgo = Date.now() - 1_800_000;
+        // We probably want locations to expire from storage. For now, we'll use
+        // the stored location only if it is less than 30 minutes old
+        if (storedLocation.timestamp > thirtyMinutesAgo) {
+          // Update the user's location in the background. Whenever this is
+          // finished, then we can update the UI. However, we can go ahead and
+          // populate the UI based on the stored location.
+          this._geolocation.getCurrentPosition(
+            this.#_getSuccess(() => {}),
+            () => {}
+          );
+          return storedLocation;
+        }
+      }
+    } catch (_) {}
+
     return new Promise((resolve, reject) => {
       this._geolocation.getCurrentPosition(
         this.#_getSuccess(resolve),

--- a/src/main.js
+++ b/src/main.js
@@ -7,10 +7,9 @@ const main = async () => {
   setupServiceWorker();
 
   try {
-    const location = await Location.get();
     const {
       coords: { latitude, longitude },
-    } = location;
+    } = await Location.get();
     document.querySelector("preload").innerText =
       "Got your location. Fetching weather...";
 
@@ -24,14 +23,20 @@ const main = async () => {
 
     loc.observations.then((o) => {
       document.getElementById("obs_text").innerText = o.text;
+
       document.getElementById(
         "obs_temperature"
       ).innerText = `${o.temperature}°F`;
+
       document.getElementById(
         "obs_time"
       ).innerText = `Last updated at ${o.timestamp.toLocaleTimeString("en-US", {
         timeStyle: "short",
       })}`;
+
+      document.getElementById("obs_loc").innerText = `at ${
+        o.stationName
+      } (about ${Math.round(o.distanceFrom(latitude, longitude))} miles away)`;
     });
 
     loc.hourlyForecast.then((forecast) => {

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,4 +1,4 @@
-const CACHE_KEY = "2023-06-26: only latest obs";
+const CACHE_KEY = "2023-07-31: obs site info";
 
 const populateCache = async () => {
   const cache = await caches.open(CACHE_KEY);
@@ -41,18 +41,52 @@ const fromCache = async (request) => {
     return match;
   }
 
-  return fetch(request);
+  // Cache a clone of the response. Responses can only be used once, at which
+  // point they can't be used again and even calling .clone() on them will fail.
+  // So clone early, clone often, I guess!
+  const response = await fetch(request);
+  cache.put(request, response.clone());
+  return response;
 };
+
+// These are API endpoints we want to cache.
+const endpointsToCache = [
+  // The list of observation stations for a given gridpoint.
+  // [TODO] This one probably should *NOT* be cached, since it's doing some
+  // temporal logic around up-ness of stations.
+  {
+    host: "api.weather.gov",
+    endpoint: /^\/gridpoints\/[A-Z]{3,4}\/\d+,\d+\/stations\/?$/i,
+  },
+
+  // The metadata for a given station. Unless we expect stations to physically
+  // move or be renamed regularly, this cache is probably fine. We may need to
+  // eventually work in some logic around expiring even these caches, though
+  { host: "api.weather.gov", endpoint: /^\/stations\/[^\/]*\/?$/i },
+];
 
 self.addEventListener("fetch", async (event) => {
   const go = async () => {
     const url = new URL(event.request.url);
+    // We should refer to the cache if this request matches any of the specified
+    // endpoints above. This is not a sufficiently robust check because it
+    // ignores the hostname, but it's good enough for proving the concept.
+    const shouldCache = endpointsToCache.some(
+      (route) =>
+        url.host.toLowerCase() === route.host &&
+        route.endpoint.test(url.pathname)
+    );
+
+    // [TEMPORARY] For api.weather.gov calls, capture them so we can get some
+    // basic performance data on them.
     if (url.host === "api.weather.gov") {
       const client = await clients.get(event.clientId);
       if (client) {
         const timerId = `timer_${Math.random() * 1000}`;
         performance.mark(`${timerId}_start`);
-        const response = await fetch(event.request);
+        const response = await (shouldCache
+          ? fromCache(event.request)
+          : fetch(event.request));
         const blob = await response.blob();
         performance.mark(`${timerId}_end`);
 


### PR DESCRIPTION
- For current conditions, the UI now displays the location of the observation station providing the data plus the (rough) distance from the user's location to that observation station
  - The `Observation` class was updated to also capture the lat/lng/altitude of the observation station and to add a helper function for computing the distance from the obs station to an arbitrary lat/lng. Altitude is currently ignored.
  - The main page was updated to add a placeholder in the dom for the ob station location and distance
  - If we decide to display distance to obs stations, we might want to see if we can get someone at the National Geodetic Survey (a NOAA office) to verify our approach is good enough. Basically, I've implemented the [Haversine distance function](https://en.wikipedia.org/wiki/Haversine_formula), which gives you the distance between two points on the surface of a sphere. My concerns here are:
    - The distance is computed based on the surface of the sphere. It does not account for points are different altitudes, which may be significant in some areas with more sparse obs station coverage.
    - The Earth is not a perfect sphere. I think we'll be dealing with relatively small distances (dozens to maybe a hundred miles), so maybe it's _close enough_ that we don't have to worry about it. Especially since I think it's also okay for our results to have an error of a mile or two, too.

    @beechnut and I talked about this, and they thought this approach was probably good enough, but I don't see any harm in getting NGS to review it if we do go that route. Matt has a background in geography, so I'm willing to trust their judgement. Certainly more than my own. 😆

- The user's browser location data is now cached in their browser. If the location data in cache is less than 30 minutes old, we use it and then update the cache in the background.
  - In the future, the background update should also trigger some downstream updates: if the user's forecast grid point changed, we should re-fetch observation stations, observations, and forecasts, and then update the UI

- The service worker now supports cacheing arbitrary requests. For a request to be cached, it must be added to a list of cacheable endpoints. When a request comes into the service worker for a matching endpoint, it is routed through the cacheing mechanism instead of fetched directly. It will only be fetched if it is not already cached. These caches currently never expire, so we'll eventually want to come back to that. (Noted in comments.)